### PR TITLE
Improve natural SEO.

### DIFF
--- a/scss/_patterns.scss
+++ b/scss/_patterns.scss
@@ -21,7 +21,7 @@
       letter-spacing: 0.8px;
       margin: 0;
     }
-    h2 {
+    span {
       font-family: "FuturaStd-Light", Sans-serif;
       font-size: 1.4rem;
       font-weight: 300;


### PR DESCRIPTION
Make, of your h2 and your h1, a single h1 so that it is correctly referenced and the difference in font size with spans inside your h1.