### PR TITLE
Add - Meta description in head

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="node_modules/normalize.css/normalize.css">
     <link rel="stylesheet" href="/style.css" />
     <title>Rosa Gaulí – Diseñadora & Artista Textil</title>
+    <meta name="description" content="Nuestras colecciones frescas y chic de suéteres, chalecos, cárdigans, chalecos largos y sudaderas de mujer de la colección Rosa Gaulí.">
 </head>
 
 <body <?php getHomePageClass(); ?>>


### PR DESCRIPTION
No need of meta keyword because google and other search engine don't use this meta in their algo: https://fr.semrush.com/blog/meta-keywords-en-seo/